### PR TITLE
Add JSON import for Figma variables

### DIFF
--- a/.figma/publishing-info.md
+++ b/.figma/publishing-info.md
@@ -1,11 +1,12 @@
 TAGLINE:
-Export Figma Variables to JSON, JS, CSV, CSS and Tailwind CSS with format-specific menu commands.
+Export Figma Variables to JSON, JS, CSV, CSS and Tailwind CSS — and import them back in from JSON — with format-specific menu commands.
 
 DESCRIPTION:
-**VarVar** is a Figma plugin that allows you to export your Figma variables to JSON, JS, CSV, CSS, or Tailwind CSS formats, making it easier to integrate your design tokens into your development workflow. Now with format-specific menu commands for faster exports!
+**VarVar** is a Figma plugin that allows you to export your Figma variables to JSON, JS, CSV, CSS, or Tailwind CSS formats, making it easier to integrate your design tokens into your development workflow. It can also import a previously exported JSON file back into a document, recreating collections, modes, variables, and linked variables. Now with format-specific menu commands for faster exports!
 
 ## Features
 **Multiple Export Formats:** JSON, JavaScript, CSV, CSS, and Tailwind CSS
+**JSON Import:** Re-populate collections, modes, variables, and linked-variable references from a previously exported JSON file, with an optional "replace existing variables" mode (deletes all existing local variable collections first, behind a confirmation dialog)
 **Format-Specific Menu Commands:** Direct access to each export format from the Figma menu
 **Linked Variable Support:** Properly handles linked variables across all formats†
 **Scope-Aware Types:** JSON, CSV, and JS exports map variable scopes (`CORNER_RADIUS`, `FONT_WEIGHT`, `OPACITY`, etc.) to DTCG `$types` instead of bare numbers
@@ -55,6 +56,15 @@ DESCRIPTION:
 - Copy the results in one click!
 
 
+### Importing Variables (JSON)
+1. Open your Figma file
+2. Run the VarVar plugin from the Plugins menu
+3. Choose **Import…**
+4. Select one or more JSON files previously exported by VarVar
+5. Optionally turn on "Replace existing variables" — this deletes all existing local variable collections before importing, so you'll be asked to confirm first
+6. Click "Import Variables"
+
+
 VarVar is open source, consider contributing. Code available on [GitHub](https://github.com/atropical/varvar).
 
 For bug reports, suggestions, or questions, please open an [issue](https://github.com/atropical/varvar/issues).
@@ -62,4 +72,4 @@ For bug reports, suggestions, or questions, please open an [issue](https://githu
 
 
 TAGS:
-variables, export variables, variables to json, variables to javascript, variables to csv, variables to css, variables to tailwind, tailwind css, developer, tokens, export, json, csv, css, design tokens, figma variables, menu commands, quick export, legacy format
+variables, export variables, variables to json, variables to javascript, variables to csv, variables to css, variables to tailwind, tailwind css, developer, tokens, export, import, import variables, json to variables, json, csv, css, design tokens, figma variables, menu commands, quick export, legacy format

--- a/.figma/publishing-info.md
+++ b/.figma/publishing-info.md
@@ -6,7 +6,7 @@ DESCRIPTION:
 
 ## Features
 **Multiple Export Formats:** JSON, JavaScript, CSV, CSS, and Tailwind CSS
-**JSON Import:** Re-populate collections, modes, variables, and linked-variable references from a previously exported JSON file, with an optional "replace existing variables" mode (deletes all existing local variable collections first, behind a confirmation dialog)
+**JSON Import§:** Re-populate collections, modes, variables, and linked-variable references from a previously exported JSON file, with an optional "replace existing variables" mode (deletes all existing local variable collections first, behind a confirmation dialog)
 **Format-Specific Menu Commands:** Direct access to each export format from the Figma menu
 **Linked Variable Support:** Properly handles linked variables across all formats†
 **Scope-Aware Types:** JSON, CSV, and JS exports map variable scopes (`CORNER_RADIUS`, `FONT_WEIGHT`, `OPACITY`, etc.) to DTCG `$types` instead of bare numbers
@@ -30,6 +30,7 @@ DESCRIPTION:
 
 † When dealing with linked variables that have multiple modes, the plugin will only link to the first occurrence (i.e., the first mode it finds).
 ‡ Enterprise fella? We'd love your feedback on this one, please open an issue with anything that looks off.
+§ A leading `.` or `_` is Figma's own convention for marking a collection, variable, or group "private" (hidden from publishing) — not unusual at all, plenty of real design systems use it. Import handles this correctly: linked-variable references are matched against your file's actual collection/mode names (so a `.` isn't confused with the JSON path separator), and any newly created collection/variable whose name starts with `.` or `_` gets `hiddenFromPublishing` set to match, so the privacy actually carries over rather than just looking private. Still review the import summary's warnings for anything it couldn't confidently match.
 
 
 

--- a/.figma/publishing-info.md
+++ b/.figma/publishing-info.md
@@ -1,12 +1,12 @@
 TAGLINE:
-Export Figma Variables to JSON, JS, CSV, CSS and Tailwind CSS — and import them back in from JSON — with format-specific menu commands.
+Export Figma Variables to JSON, JS, CSV, CSS and Tailwind CSS. Import them back in from JSON.
 
 DESCRIPTION:
-**VarVar** is a Figma plugin that allows you to export your Figma variables to JSON, JS, CSV, CSS, or Tailwind CSS formats, making it easier to integrate your design tokens into your development workflow. It can also import a previously exported JSON file back into a document, recreating collections, modes, variables, and linked variables. Now with format-specific menu commands for faster exports!
+**VarVar** is a Figma plugin that allows you to export your Figma variables to JSON, JS, CSV, CSS, or Tailwind CSS formats, making it easier to integrate your design tokens into your development workflow. It can also import a previously exported JSON file back into a document, recreating collections, modes, variables, and linked variables.
 
 ## Features
 **Multiple Export Formats:** JSON, JavaScript, CSV, CSS, and Tailwind CSS
-**JSON Import§:** Re-populate collections, modes, variables, and linked-variable references from a previously exported JSON file, with an optional "replace existing variables" mode (deletes all existing local variable collections first, behind a confirmation dialog)
+**JSON Import§:** Re-populate collections, modes, variables, and linked-variable references from a previously exported JSON file, with an optional "replace existing variables" mode
 **Format-Specific Menu Commands:** Direct access to each export format from the Figma menu
 **Linked Variable Support:** Properly handles linked variables across all formats†
 **Scope-Aware Types:** JSON, CSV, and JS exports map variable scopes (`CORNER_RADIUS`, `FONT_WEIGHT`, `OPACITY`, etc.) to DTCG `$types` instead of bare numbers
@@ -30,7 +30,7 @@ DESCRIPTION:
 
 † When dealing with linked variables that have multiple modes, the plugin will only link to the first occurrence (i.e., the first mode it finds).
 ‡ Enterprise fella? We'd love your feedback on this one, please open an issue with anything that looks off.
-§ A leading `.` or `_` is Figma's own convention for marking a collection, variable, or group "private" (hidden from publishing) — not unusual at all, plenty of real design systems use it. Import handles this correctly: linked-variable references are matched against your file's actual collection/mode names (so a `.` isn't confused with the JSON path separator), and any newly created collection/variable whose name starts with `.` or `_` gets `hiddenFromPublishing` set to match, so the privacy actually carries over rather than just looking private. Still review the import summary's warnings for anything it couldn't confidently match.
+§ A leading `.` or `_` is Figma's own convention for marking a collection, variable, or group "private" (hidden from publishing). Import handles this correctly: linked-variable references are matched against your file's actual collection/mode names (so a `.` isn't confused with the JSON path separator), and any newly created collection/variable whose name starts with `.` or `_` gets `hiddenFromPublishing` set to match, so the privacy actually carries over rather than just looking private. Still review the import summary's warnings for anything it couldn't confidently match.
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,7 @@ Before submitting a PR, test the following:
 4. **Error handling**: Test with edge cases and invalid data
 5. **UI responsiveness**: Check different screen sizes
 6. **File downloads**: Verify files are downloaded correctly
+7. **JSON import**: Round-trip an export back in (merge and replace-existing paths), including cross-collection linked variables and a broken/`_unlinked` reference
 
 ### Automated Testing
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # VarVar - Figma Variable Export Plugin
 
-VarVar is a Figma plugin that allows you to export your Figma variables to JSON, CSV, CSS, or JavaScript formats, making it easier to integrate your design tokens into your development workflow.
+VarVar is a Figma plugin that allows you to export your Figma variables to JSON, CSV, CSS, or JavaScript formats, and import them back in from JSON, making it easier to integrate your design tokens into your development workflow.
 
 ## Features
 
 - **Multiple Export Formats**: Export Figma variables to JSON, CSV, CSS (vanilla or Tailwind CSS v4), or JavaScript
+- **JSON Import**: Re-populate collections, modes, variables, and linked-variable references from a previously exported JSON file, with an optional "replace existing variables" mode — see below. CSV/CSS/JS import isn't supported, since those formats aren't reliable round-trip sources.
 - **Format-Specific Menu Commands**: Direct access to each export format from the Figma menu
 - **Linked Variable Support**: Identifies and properly handles linked variables across formats
 - **Scope-Aware Types**: JSON, CSV, and JS exports map variable scopes (`CORNER_RADIUS`, `FONT_WEIGHT`, `OPACITY`, etc.) to DTCG `$type`s instead of exporting bare numbers
@@ -77,6 +78,16 @@ For format selection within the interface:
 
 > **Note:** Programmatically copying is currently not supported by Figma Plugin APIs.
 
+### Import
+
+1. Open your Figma file
+2. Go to **Plugins** → **VarVar** → **Import…**
+3. Choose one or more JSON files previously exported by VarVar (current or legacy format; if you exported an Enterprise extended-collection `.zip`, select its unzipped files together)
+4. Optionally toggle **Replace existing variables** — this deletes *every* existing local variable collection in the file before importing, not just the ones named in the JSON, so you'll be asked to confirm before it runs
+5. Click "Import Variables" — collections, modes, variables, and linked-variable references are recreated, and a summary of what was created/updated (plus any warnings) is shown
+
+> **Note:** Only JSON is supported for import — CSV, CSS, and JS aren't reliable round-trip sources for reconstructing variables.
+
 ## Architecture
 
 VarVar is built with a modular architecture for maintainability and scalability:
@@ -100,21 +111,28 @@ src/
 │   ├── ExportButton.tsx
 │   ├── OutputPreview.tsx
 │   ├── ExportOptions.tsx
+│   ├── FileImportInput.tsx    # File picker for JSON import
+│   ├── ImportOptions.tsx      # "Replace existing variables" toggle
+│   ├── ConfirmReplaceDialog.tsx  # Confirmation for the replace-existing import path
+│   ├── ImportSummaryPanel.tsx # Import result counts and warnings
 │   └── Footer.tsx
 ├── hooks/              # Custom React hooks
-│   └── useExportData.ts    # Hook for managing export data and state
-├── views/              # Format-specific export views
+│   ├── useExportData.ts    # Hook for managing export data and state
+│   └── useImportData.ts    # Hook for managing import data and state
+├── views/              # Format-specific export/import views
 │   ├── ExportView.tsx      # Generic export with format selector
 │   ├── ExportJSON.tsx
 │   ├── ExportCSV.tsx
 │   ├── ExportCSS.tsx
-│   └── ExportJS.tsx
-├── utils/              # Export processing utilities
+│   ├── ExportJS.tsx
+│   └── ImportJSON.tsx      # JSON import view
+├── utils/              # Export/import processing utilities
 │   ├── collectionToJSON.ts
 │   ├── collectionToCSV.ts
 │   ├── collectionToCSS.ts
 │   ├── collectionToJS.ts
 │   ├── collectionToTailwind.ts
+│   ├── importJSON.ts       # Parses exported JSON and recreates variables in Figma
 │   ├── clipboard.ts
 │   ├── color.ts
 │   └── stringTransformation.ts

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ For format selection within the interface:
 
 > **Note:** Only JSON is supported for import — CSV, CSS, and JS aren't reliable round-trip sources for reconstructing variables.
 
+> **Note:** A leading `.` or `_` is Figma's own convention for marking a collection, variable, or group "private" (hidden from publishing) — common in real design systems, not an edge case. Import handles it correctly: linked-variable references are matched against your file's actual collection/mode names rather than blindly split on `.`, and any newly created collection/variable whose name starts with `.` or `_` gets `hiddenFromPublishing` set to match, so the privacy actually carries over. Check the import summary's warnings for anything it couldn't confidently match.
+
 ## Architecture
 
 VarVar is built with a modular architecture for maintainability and scalability:

--- a/figma.manifest.ts
+++ b/figma.manifest.ts
@@ -16,7 +16,9 @@ export default {
       ]
     },
     {"separator": true},
-    { "command": "export", "name": "Export Variables" }
+    { "command": "export", "name": "Export Variables" },
+    {"separator": true},
+    { "command": "import-json", "name": "Import…" }
   ],
   "documentAccess": "dynamic-page",
   "networkAccess": {

--- a/src/code.ts
+++ b/src/code.ts
@@ -8,6 +8,7 @@ import { exportToJS } from "./utils/collectionToJS";
 import { toLegacyJSON } from "./utils/legacyJsonConverter";
 import { toLegacyCSV } from "./utils/legacyCsvConverter";
 import { toLegacyJS } from "./utils/legacyJsConverter";
+import { importVariables } from "./utils/importJSON";
 import { OutputFormats, MessageTypes, PluginCommands, PluginMessage, ExportFile } from "./types.d";
 
 figma.showUI(__html__, { width: 800, height: 500, themeColors: true });
@@ -111,6 +112,34 @@ async function handleExport(format: OutputFormats, useLinkedVarRowAndColPos: boo
 }
 
 /**
+ * Handles import requests: parses the uploaded JSON file(s) and recreates
+ * collections, modes, variables and their values (including linked variables)
+ * in the current document.
+ */
+async function handleImport(importFiles: string[], replaceExisting: boolean) {
+    try {
+        const importSummary = await importVariables(importFiles, replaceExisting);
+
+        figma.ui.postMessage({
+            type: MessageTypes.IMPORT_SUCCESS_RESULT,
+            importSummary,
+        } as PluginMessage);
+
+        figma.notify('✅ Variables were imported.');
+    } catch (error) {
+        console.error(error);
+        figma.notify('Something went wrong while attempting to import the variables. Check the console for more info.', {
+            error: true
+        });
+
+        figma.ui.postMessage({
+            type: MessageTypes.IMPORT_ERROR,
+            error: error instanceof Error ? error.message : 'Unknown error occurred'
+        } as PluginMessage);
+    }
+}
+
+/**
  * Main message handler for plugin communication
  */
 figma.ui.onmessage = async (msg: PluginMessage) => {
@@ -118,7 +147,7 @@ figma.ui.onmessage = async (msg: PluginMessage) => {
         case MessageTypes.GET_BASIC_INFO:
             await handleBasicInfo(msg.command);
             break;
-            
+
         case MessageTypes.EXPORT_SUCCESS:
             if (msg.format) {
                 await handleExport(msg.format, msg.useLinkedVarRowAndColPos || false, msg.useTailwindFormat || false, msg.useLegacyFormat || false);
@@ -126,7 +155,15 @@ figma.ui.onmessage = async (msg: PluginMessage) => {
                 console.error('Export request missing format');
             }
             break;
-            
+
+        case MessageTypes.IMPORT_REQUEST:
+            if (msg.importFiles && msg.importFiles.length > 0) {
+                await handleImport(msg.importFiles, msg.replaceExisting || false);
+            } else {
+                console.error('Import request missing files');
+            }
+            break;
+
         default:
             console.warn(`Unknown message type: ${msg.type}`);
     }

--- a/src/components/ConfirmReplaceDialog.tsx
+++ b/src/components/ConfirmReplaceDialog.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { AlertDialog, Button } from "figma-kit";
+
+interface ConfirmReplaceDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onConfirm: () => void;
+}
+
+/**
+ * Confirmation gate for the destructive "replace existing variables" import
+ * path. Shown only when the user triggers an import with that toggle on.
+ */
+export const ConfirmReplaceDialog: React.FC<ConfirmReplaceDialogProps> = ({
+    open,
+    onOpenChange,
+    onConfirm
+}) => {
+    return (
+        <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
+            <AlertDialog.Content>
+                <AlertDialog.Title>Replace existing variables?</AlertDialog.Title>
+                <AlertDialog.Description>
+                    This deletes <strong>all</strong> existing local variable collections
+                    in this file — not just the ones named in the JSON you're importing —
+                    and then recreates everything from the file. This can&apos;t be undone
+                    through the plugin; Figma&apos;s own undo (Cmd/Ctrl+Z) right afterwards
+                    may still work.
+                </AlertDialog.Description>
+                <AlertDialog.Actions>
+                    <AlertDialog.Cancel>
+                        <Button variant="secondary">Cancel</Button>
+                    </AlertDialog.Cancel>
+                    <AlertDialog.Action onClick={onConfirm}>
+                        <Button variant="destructive">Delete and import</Button>
+                    </AlertDialog.Action>
+                </AlertDialog.Actions>
+            </AlertDialog.Content>
+        </AlertDialog.Root>
+    );
+};

--- a/src/components/FileImportInput.tsx
+++ b/src/components/FileImportInput.tsx
@@ -1,0 +1,72 @@
+import React, { useRef } from "react";
+import { Flex, Text, Label, Button } from "figma-kit";
+
+interface FileImportInputProps {
+    fileNames: string[];
+    onFilesSelected: (fileNames: string[], contents: string[]) => void;
+}
+
+/**
+ * File picker for uploading one or more previously-exported VarVar JSON
+ * files. figma-kit has no file-input equivalent, so this wraps a hidden
+ * native `<input type="file">` and drives it from a figma-kit Button to
+ * match the rest of the plugin's UI. Reads each selected file as text and
+ * hands the raw contents up — parsing/validation happens in the plugin
+ * sandbox, not the UI.
+ */
+export const FileImportInput: React.FC<FileImportInputProps> = ({
+    fileNames,
+    onFilesSelected
+}) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = e.target.files;
+        if (!files || files.length === 0) return;
+
+        const fileList = Array.from(files);
+        const contents = await Promise.all(fileList.map((file) => file.text()));
+        onFilesSelected(fileList.map((file) => file.name), contents);
+    };
+
+    return (
+        <Flex gap="2" direction="column">
+            <Label style={{ color: 'var(--figma-color-text-secondary)' }} htmlFor="varvar-import-file">
+                JSON file
+            </Label>
+
+            <input
+                ref={inputRef}
+                id="varvar-import-file"
+                type="file"
+                accept="application/json,.json"
+                multiple
+                onChange={handleChange}
+                style={{ display: "none" }}
+            />
+
+            <Button
+                variant="secondary"
+                size="medium"
+                fullWidth={true}
+                onClick={() => inputRef.current?.click()}
+            >
+                {fileNames.length > 0 ? "Choose different file(s)…" : "Choose JSON file(s)…"}
+            </Button>
+
+            {fileNames.length > 0 && (
+                <Flex direction="column" gap="1" style={{
+                    padding: "0.5rem",
+                    border: "1px solid var(--figma-color-border)",
+                    borderRadius: "4px",
+                }}>
+                    {fileNames.map((name) => (
+                        <Text key={name} style={{ color: 'var(--figma-color-text-secondary)' }}>
+                            {name}
+                        </Text>
+                    ))}
+                </Flex>
+            )}
+        </Flex>
+    );
+};

--- a/src/components/ImportOptions.tsx
+++ b/src/components/ImportOptions.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Flex, Switch, Label, Text } from "figma-kit";
+
+interface ImportOptionsProps {
+    replaceExisting: boolean;
+    onReplaceExistingChange: (replaceExisting: boolean) => void;
+}
+
+/**
+ * Import-specific options: the "replace existing variables" toggle. This is
+ * destructive (wipes every local variable collection before importing), so
+ * it defaults to off and is always followed by a confirmation dialog.
+ */
+export const ImportOptions: React.FC<ImportOptionsProps> = ({
+    replaceExisting,
+    onReplaceExistingChange
+}) => {
+    return (
+        <Flex gap="2" direction="column">
+            <Label style={{ color: 'var(--figma-color-text-secondary)' }}>
+                Options
+            </Label>
+
+            <Flex gap="2">
+                <Switch
+                    id="varvar-import-replace-existing"
+                    onCheckedChange={onReplaceExistingChange}
+                    checked={replaceExisting}
+                    style={{ flexShrink: 0 }}
+                />
+                <Label htmlFor="varvar-import-replace-existing">
+                    Replace existing variables
+                </Label>
+                <span title="Deletes every existing local variable collection in this file before importing, so the result matches the JSON exactly. This is not limited to collections named in the file — everything is wiped first. You'll be asked to confirm." style={{ backgroundColor: 'var(--figma-color-text-secondary)', fontFamily: 'sans-serif', cursor: 'help', userSelect: 'none', color: 'var(--figma-color-text-secondary-inverse)', borderRadius: '50%', padding: '1px', fontSize: '.6em', width: '1em', height: '1em', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>?</span>
+            </Flex>
+
+            {replaceExisting && (
+                <Flex style={{
+                    padding: "0.5rem",
+                    borderRadius: "4px",
+                    backgroundColor: "rgba(234, 179, 8, 0.15)",
+                }}>
+                    <Text weight="strong" style={{ color: 'var(--figma-color-text)' }}>
+                        Warning: this deletes all existing variables before importing
+                    </Text>
+                </Flex>
+            )}
+        </Flex>
+    );
+};

--- a/src/components/ImportSummaryPanel.tsx
+++ b/src/components/ImportSummaryPanel.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Flex, Text } from "figma-kit";
+import type { ImportSummary } from "../types.d";
+
+interface ImportSummaryPanelProps {
+    summary: ImportSummary;
+    editorType?: string;
+}
+
+/**
+ * Displays the result of an import run: what was created/reused/updated,
+ * and any non-fatal warnings (unresolved aliases, `_unlinked` entries, etc.).
+ * Mirrors OutputPreview's panel styling so import and export views share the
+ * same right-hand-side "report" layout.
+ */
+export const ImportSummaryPanel: React.FC<ImportSummaryPanelProps> = ({ summary, editorType = 'dev' }) => {
+    return (
+        <Flex direction="column" gap="2" style={{ flex: "2 0 300px", maxWidth: editorType === 'design' ? "454px" : undefined }}>
+            <Text>Import Summary</Text>
+
+            <Flex
+                direction="column"
+                gap="2"
+                style={{
+                    border: 'var(--figma-color-border)',
+                    borderRadius: 4,
+                    padding: 8,
+                    backgroundColor: 'rgba(0,0,0,.25)',
+                }}
+            >
+                <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
+                    Collections: {summary.collectionsCreated} created, {summary.collectionsReused} reused
+                </Text>
+                <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
+                    Modes created: {summary.modesCreated}
+                </Text>
+                <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
+                    Variables: {summary.variablesCreated} created, {summary.variablesUpdated} updated
+                </Text>
+                <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
+                    Values set: {summary.valuesSet} ({summary.aliasesResolved} linked variables)
+                </Text>
+            </Flex>
+
+            {summary.warnings.length > 0 && (
+                <details style={{
+                    padding: "0.5rem",
+                    borderRadius: "4px",
+                    backgroundColor: "rgba(234, 179, 8, 0.15)",
+                    color: 'var(--figma-color-text)',
+                }}>
+                    <summary style={{ cursor: 'pointer' }}>
+                        <Text weight="strong" style={{ display: 'inline' }}>
+                            Summary: {summary.warnings.length} warning{summary.warnings.length === 1 ? '' : 's'}
+                        </Text>
+                    </summary>
+                    <Flex direction="column" gap="1" style={{ marginTop: '0.5rem' }}>
+                        <Text weight="strong">Detail</Text>
+                        {summary.warnings.map((warning, index) => (
+                            <Text key={index}>{warning}</Text>
+                        ))}
+                    </Flex>
+                </details>
+            )}
+        </Flex>
+    );
+};

--- a/src/hooks/useImportData.ts
+++ b/src/hooks/useImportData.ts
@@ -1,0 +1,94 @@
+import { useState, useEffect } from "react";
+import { MessageTypes, ImportSummary } from "../types.d";
+
+interface UseImportDataReturn {
+    fileNames: string[];
+    fileContents: string[];
+    setFiles: (fileNames: string[], fileContents: string[]) => void;
+    replaceExisting: boolean;
+    setReplaceExisting: (replaceExisting: boolean) => void;
+    confirmDialogOpen: boolean;
+    setConfirmDialogOpen: (open: boolean) => void;
+    isImporting: boolean;
+    importSummary: ImportSummary | null;
+    importError: string | null;
+    handleImportClick: () => void;
+    handleConfirmReplace: () => void;
+}
+
+/**
+ * Custom hook that owns the import view's state and all postMessage traffic
+ * for the import flow, mirroring useExportData's structure for the reverse
+ * direction.
+ */
+export const useImportData = (): UseImportDataReturn => {
+    const [fileNames, setFileNames] = useState<string[]>([]);
+    const [fileContents, setFileContents] = useState<string[]>([]);
+    const [replaceExisting, setReplaceExisting] = useState<boolean>(false);
+    const [confirmDialogOpen, setConfirmDialogOpen] = useState<boolean>(false);
+    const [isImporting, setIsImporting] = useState<boolean>(false);
+    const [importSummary, setImportSummary] = useState<ImportSummary | null>(null);
+    const [importError, setImportError] = useState<string | null>(null);
+
+    const setFiles = (names: string[], contents: string[]) => {
+        setFileNames(names);
+        setFileContents(contents);
+        setImportSummary(null);
+        setImportError(null);
+    };
+
+    const sendImportRequest = () => {
+        setIsImporting(true);
+        setImportSummary(null);
+        setImportError(null);
+        parent.postMessage({
+            pluginMessage: {
+                type: MessageTypes.IMPORT_REQUEST,
+                importFiles: fileContents,
+                replaceExisting
+            }
+        }, "*");
+    };
+
+    const handleImportClick = () => {
+        if (fileContents.length === 0) return;
+
+        if (replaceExisting) {
+            setConfirmDialogOpen(true);
+        } else {
+            sendImportRequest();
+        }
+    };
+
+    const handleConfirmReplace = () => {
+        setConfirmDialogOpen(false);
+        sendImportRequest();
+    };
+
+    useEffect(() => {
+        window.onmessage = ({ data: { pluginMessage } }) => {
+            if (pluginMessage.type === MessageTypes.IMPORT_SUCCESS_RESULT) {
+                setIsImporting(false);
+                setImportSummary(pluginMessage.importSummary);
+            } else if (pluginMessage.type === MessageTypes.IMPORT_ERROR) {
+                setIsImporting(false);
+                setImportError(pluginMessage.error || "Unknown error occurred");
+            }
+        };
+    }, []);
+
+    return {
+        fileNames,
+        fileContents,
+        setFiles,
+        replaceExisting,
+        setReplaceExisting,
+        confirmDialogOpen,
+        setConfirmDialogOpen,
+        isImporting,
+        importSummary,
+        importError,
+        handleImportClick,
+        handleConfirmReplace
+    };
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -75,9 +75,10 @@ export enum OutputFormats {
 export enum PluginCommands {
   EXPORT_GENERIC = "export",
   EXPORT_JSON = "export-json",
-  EXPORT_CSV = "export-csv", 
+  EXPORT_CSV = "export-csv",
   EXPORT_CSS = "export-css",
-  EXPORT_JS = "export-js"
+  EXPORT_JS = "export-js",
+  IMPORT_JSON = "import-json"
 }
 
 /**
@@ -87,11 +88,16 @@ export enum MessageTypes {
   // Info messages
   GET_BASIC_INFO = "INFO.GET_BASIC_INFO",
   BASIC_INFO = "INFO.BASIC_INFO",
-  
+
   // Export messages
   EXPORT_SUCCESS = "EXPORT.SUCCESS",
   EXPORT_SUCCESS_RESULT = "EXPORT.SUCCESS.RESULT",
-  EXPORT_ERROR = "EXPORT.ERROR"
+  EXPORT_ERROR = "EXPORT.ERROR",
+
+  // Import messages
+  IMPORT_REQUEST = "IMPORT.REQUEST",
+  IMPORT_SUCCESS_RESULT = "IMPORT.SUCCESS.RESULT",
+  IMPORT_ERROR = "IMPORT.ERROR"
 }
 
 /**
@@ -102,6 +108,22 @@ export enum MessageTypes {
 export interface ExportFile {
   filename: string;
   content: string;
+}
+
+/**
+ * Summary of an import run: counts of what was created/reused/updated, plus
+ * any non-fatal warnings (unresolved aliases, `_unlinked` entries, mode-limit
+ * errors, type mismatches) collected along the way.
+ */
+export interface ImportSummary {
+  collectionsCreated: number;
+  collectionsReused: number;
+  modesCreated: number;
+  variablesCreated: number;
+  variablesUpdated: number;
+  valuesSet: number;
+  aliasesResolved: number;
+  warnings: string[];
 }
 
 /**
@@ -121,4 +143,7 @@ export interface PluginMessage {
   usedExtendedCollections?: boolean;
   error?: string;
   editorType?: string;
+  importFiles?: string[];
+  replaceExisting?: boolean;
+  importSummary?: ImportSummary;
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -7,6 +7,7 @@ import { ExportJSON } from "./views/ExportJSON";
 import { ExportCSV } from "./views/ExportCSV";
 import { ExportCSS } from "./views/ExportCSS";
 import { ExportJS } from "./views/ExportJS";
+import { ImportJSON } from "./views/ImportJSON";
 
 /**
  * Main App component that routes to format-specific views based on command
@@ -42,6 +43,8 @@ const App: React.FC = () => {
             return <ExportCSS editorType={editorType} />;
         case PluginCommands.EXPORT_JS:
             return <ExportJS editorType={editorType} />;
+        case PluginCommands.IMPORT_JSON:
+            return <ImportJSON editorType={editorType} />;
         case PluginCommands.EXPORT_GENERIC:
         default:
             return <ExportView editorType={editorType} />;

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -29,3 +29,39 @@ export const rgbToCssColor = ({ r, g, b, a = 1 }: RGBA): CssColor => {
   const hex = [toHex(r), toHex(g), toHex(b)].join("");
   return `#${hex}`;
 };
+
+/**
+ * Parses a CSS color string (as produced by `rgbToCssColor`: `#rrggbb`/`#rgb`
+ * hex, or `rgba(r, g, b, a)`) back into an RGBA value with 0-1 float channels.
+ * @param {string} css - The CSS color string to parse
+ * @returns {RGBA} The parsed RGBA color
+ */
+export const cssColorToRgba = (css: string): RGBA => {
+  const trimmed = css.trim();
+
+  const rgbaMatch = /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*(?:,\s*([\d.]+)\s*)?\)$/i.exec(trimmed);
+  if (rgbaMatch) {
+    const [, r, g, b, a] = rgbaMatch;
+    return {
+      r: parseFloat(r) / 255,
+      g: parseFloat(g) / 255,
+      b: parseFloat(b) / 255,
+      a: a !== undefined ? parseFloat(a) : 1,
+    } as RGBA;
+  }
+
+  const hexMatch = /^#([0-9a-f]{3,8})$/i.exec(trimmed);
+  if (hexMatch) {
+    let hex = hexMatch[1];
+    if (hex.length === 3 || hex.length === 4) {
+      hex = hex.split("").map((c) => c + c).join("");
+    }
+    const r = parseInt(hex.slice(0, 2), 16) / 255;
+    const g = parseInt(hex.slice(2, 4), 16) / 255;
+    const b = parseInt(hex.slice(4, 6), 16) / 255;
+    const a = hex.length === 8 ? parseInt(hex.slice(6, 8), 16) / 255 : 1;
+    return { r, g, b, a } as RGBA;
+  }
+
+  throw new Error(`Unrecognized CSS color value: "${css}"`);
+};

--- a/src/utils/importJSON.ts
+++ b/src/utils/importJSON.ts
@@ -1,0 +1,380 @@
+import { cssColorToRgba } from "./color";
+import { getMatchingModeName } from "./variableUtils";
+import type { ImportSummary } from "../types.d";
+
+const validTypes = new Set(["COLOR", "FLOAT", "BOOLEAN", "STRING"]);
+
+/**
+ * Fallback mapping from DTCG `$type` names to Figma's raw resolved types, used
+ * when a leaf has neither `$extensions.figma.resolvedType` (current shape)
+ * nor a raw `$type` (legacy shape) to read the resolved type from directly —
+ * i.e. a plain DTCG token file that was never a VarVar export.
+ */
+const DTCG_TYPE_TO_RESOLVED_TYPE: Record<string, VariableResolvedDataType> = {
+  color: "COLOR",
+  dimension: "FLOAT",
+  number: "FLOAT",
+  fontWeight: "FLOAT",
+  boolean: "BOOLEAN",
+  string: "STRING",
+  fontFamily: "STRING",
+};
+
+interface ImportFileEntry {
+  collection: string;
+  mode: string;
+  variables: Record<string, unknown>;
+}
+
+interface ImportRecord {
+  collectionName: string;
+  modeName: string;
+  pathParts: string[];
+  resolvedType: VariableResolvedDataType;
+  scopes: VariableScope[];
+  description: string;
+  rawValue: unknown;
+}
+
+function isTokenLeaf(node: unknown): node is Record<string, unknown> {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    "$type" in node &&
+    "$value" in node
+  );
+}
+
+/**
+ * Reads a token leaf produced by the current (v3.x, `$extensions.figma`) or
+ * legacy (v2.x, sibling `$scopes`, raw `$type`) exporter shape, falling back
+ * to mapping a plain DTCG `$type` (e.g. hand-authored token files) when
+ * neither is present. Returns `undefined` `resolvedType` if the type can't be
+ * resolved at all.
+ */
+function normalizeLeaf(node: Record<string, unknown>): {
+  resolvedType: VariableResolvedDataType | undefined;
+  scopes: VariableScope[];
+  description: string;
+  rawValue: unknown;
+} {
+  const extensions = node.$extensions as { figma?: { scopes?: VariableScope[]; resolvedType?: VariableResolvedDataType } } | undefined;
+  const figma = extensions?.figma;
+
+  const rawType = node.$type as string | undefined;
+  const resolvedType = figma?.resolvedType
+    ?? (rawType && validTypes.has(rawType) ? (rawType as VariableResolvedDataType) : undefined)
+    ?? (rawType ? DTCG_TYPE_TO_RESOLVED_TYPE[rawType] : undefined);
+
+  const scopes = figma?.scopes ?? (node.$scopes as VariableScope[] | undefined) ?? [];
+  const description = (node.$description as string) ?? "";
+
+  return { resolvedType, scopes, description, rawValue: node.$value };
+}
+
+function walkVariables(
+  variables: Record<string, unknown>,
+  collectionName: string,
+  modeName: string,
+  pathParts: string[],
+  records: ImportRecord[],
+  warnings: string[]
+): void {
+  for (const [key, node] of Object.entries(variables)) {
+    if (isTokenLeaf(node)) {
+      const { resolvedType, scopes, description, rawValue } = normalizeLeaf(node);
+      const path = [...pathParts, key].join("/");
+      if (!resolvedType || !validTypes.has(resolvedType)) {
+        warnings.push(`Skipped "${path}" in "${collectionName}" (${modeName}): unrecognized or unsupported $type "${String(node.$type)}".`);
+        continue;
+      }
+      records.push({
+        collectionName,
+        modeName,
+        pathParts: [...pathParts, key],
+        resolvedType,
+        scopes,
+        description,
+        rawValue,
+      });
+    } else if (typeof node === "object" && node !== null) {
+      walkVariables(node as Record<string, unknown>, collectionName, modeName, [...pathParts, key], records, warnings);
+    }
+  }
+}
+
+/**
+ * Parses and merges every raw JSON file's `{collection, mode, variables}[]`
+ * array into a flat list of per-variable-per-mode records.
+ */
+function collectRecords(rawFiles: string[]): { records: ImportRecord[]; warnings: string[] } {
+  const records: ImportRecord[] = [];
+  const warnings: string[] = [];
+
+  for (const raw of rawFiles) {
+    const entries: ImportFileEntry[] = JSON.parse(raw);
+    for (const entry of entries) {
+      walkVariables(entry.variables, entry.collection, entry.mode, [], records, warnings);
+    }
+  }
+
+  return { records, warnings };
+}
+
+interface AliasReference {
+  collectionName: string;
+  modeName: string;
+  path: string;
+}
+
+/**
+ * Parses a `$.Collection.Mode.path` (or same-collection `$..Mode.path`)
+ * alias-reference string back into its parts. Returns `null` for anything
+ * that isn't the alias-reference convention (including `"_unlinked"`).
+ */
+export function parseAliasReference(value: unknown, currentCollectionName: string): AliasReference | null {
+  if (typeof value !== "string" || !value.startsWith("$.")) {
+    return null;
+  }
+
+  const remainder = value.slice(2);
+  const sameCollection = remainder.startsWith(".");
+  const body = sameCollection ? remainder.slice(1) : remainder;
+
+  const parts = body.split(".");
+  if (sameCollection) {
+    const [modeName, ...pathParts] = parts;
+    if (!modeName || pathParts.length === 0) return null;
+    return { collectionName: currentCollectionName, modeName, path: pathParts.join("/") };
+  }
+
+  const [collectionName, modeName, ...pathParts] = parts;
+  if (!collectionName || !modeName || pathParts.length === 0) return null;
+  return { collectionName, modeName, path: pathParts.join("/") };
+}
+
+function parseLiteralValue(
+  rawValue: unknown,
+  resolvedType: VariableResolvedDataType
+): VariableValue {
+  switch (resolvedType) {
+    case "COLOR":
+      return cssColorToRgba(String(rawValue));
+    case "FLOAT":
+      return parseFloat(String(rawValue));
+    case "BOOLEAN":
+      return Boolean(rawValue);
+    default:
+      return String(rawValue);
+  }
+}
+
+/**
+ * Imports a set of previously-exported VarVar JSON files into the current
+ * Figma document: recreates collections, modes and variables, sets literal
+ * values, and resolves the plugin's `$.Collection.Mode.path` alias-reference
+ * convention back into real Figma variable aliases.
+ *
+ * @param rawFiles - Raw JSON text of each selected file
+ * @param replaceExisting - If true, every existing local variable collection
+ *   is deleted before importing (a clean re-sync instead of an additive merge)
+ */
+export async function importVariables(rawFiles: string[], replaceExisting: boolean): Promise<ImportSummary> {
+  const summary: ImportSummary = {
+    collectionsCreated: 0,
+    collectionsReused: 0,
+    modesCreated: 0,
+    variablesCreated: 0,
+    variablesUpdated: 0,
+    valuesSet: 0,
+    aliasesResolved: 0,
+    warnings: [],
+  };
+
+  const { records, warnings: parseWarnings } = collectRecords(rawFiles);
+  summary.warnings.push(...parseWarnings);
+
+  if (records.length === 0) {
+    summary.warnings.push("No importable variables were found in the selected file(s) — nothing was changed.");
+    return summary;
+  }
+
+  if (replaceExisting) {
+    const existing = await figma.variables.getLocalVariableCollectionsAsync();
+    for (const collection of existing) {
+      collection.remove();
+    }
+  }
+
+  // --- Phase 1: collections & modes ---
+  const collectionsByName = new Map<string, VariableCollection>();
+  {
+    const existing = await figma.variables.getLocalVariableCollectionsAsync();
+    for (const collection of existing) {
+      collectionsByName.set(collection.name, collection);
+    }
+  }
+
+  const modeNamesByCollection = new Map<string, string[]>();
+  for (const record of records) {
+    const modeNames = modeNamesByCollection.get(record.collectionName) ?? [];
+    if (!modeNames.includes(record.modeName)) modeNames.push(record.modeName);
+    modeNamesByCollection.set(record.collectionName, modeNames);
+  }
+
+  for (const [collectionName, modeNames] of modeNamesByCollection) {
+    let collection = collectionsByName.get(collectionName);
+    let isNewCollection = false;
+    if (!collection) {
+      collection = figma.variables.createVariableCollection(collectionName);
+      collectionsByName.set(collectionName, collection);
+      summary.collectionsCreated += 1;
+      isNewCollection = true;
+    } else {
+      summary.collectionsReused += 1;
+    }
+
+    modeNames.forEach((modeName, index) => {
+      const existingMode = collection!.modes.find((m) => m.name === modeName);
+      if (existingMode) return;
+
+      if (isNewCollection && index === 0) {
+        // Rename the collection's auto-created default mode instead of adding a new one.
+        collection!.renameMode(collection!.modes[0].modeId, modeName);
+        summary.modesCreated += 1;
+        return;
+      }
+
+      try {
+        collection!.addMode(modeName);
+        summary.modesCreated += 1;
+      } catch (err) {
+        summary.warnings.push(
+          `Could not add mode "${modeName}" to collection "${collectionName}": ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    });
+  }
+
+  // --- Phase 2: variables ---
+  const variablesByCollectionAndPath = new Map<string, Variable>();
+  const seenPaths = new Set<string>();
+
+  for (const record of records) {
+    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
+    if (seenPaths.has(pathKey)) continue;
+    seenPaths.add(pathKey);
+
+    const collection = collectionsByName.get(record.collectionName);
+    if (!collection) continue;
+
+    const varName = record.pathParts.join("/");
+    const existingVariables = await Promise.all(
+      collection.variableIds.map((id) => figma.variables.getVariableByIdAsync(id))
+    );
+    const existingVariable = existingVariables.find((v) => v !== null && v.name === varName) as Variable | undefined;
+
+    let variable: Variable;
+    if (existingVariable) {
+      if (existingVariable.resolvedType !== record.resolvedType) {
+        summary.warnings.push(
+          `Skipped variable "${varName}" in "${record.collectionName}": existing type ${existingVariable.resolvedType} does not match imported type ${record.resolvedType}.`
+        );
+        continue;
+      }
+      variable = existingVariable;
+      summary.variablesUpdated += 1;
+    } else {
+      variable = figma.variables.createVariable(varName, collection, record.resolvedType);
+      summary.variablesCreated += 1;
+    }
+
+    variable.description = record.description;
+    if (record.scopes.length > 0 && !record.scopes.includes("ALL_SCOPES")) {
+      variable.scopes = record.scopes;
+    }
+
+    variablesByCollectionAndPath.set(pathKey, variable);
+  }
+
+  // --- Phase 3: values (literals first, then aliases so every variable already exists) ---
+  const aliasRecords: ImportRecord[] = [];
+
+  for (const record of records) {
+    if (typeof record.rawValue === "string" && record.rawValue === "_unlinked") {
+      summary.warnings.push(
+        `Skipped unlinked reference for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}).`
+      );
+      continue;
+    }
+    if (parseAliasReference(record.rawValue, record.collectionName)) {
+      aliasRecords.push(record);
+      continue;
+    }
+
+    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
+    const variable = variablesByCollectionAndPath.get(pathKey);
+    const collection = collectionsByName.get(record.collectionName);
+    if (!variable || !collection) continue;
+
+    const mode = collection.modes.find((m) => m.name === record.modeName);
+    if (!mode) continue;
+
+    try {
+      variable.setValueForMode(mode.modeId, parseLiteralValue(record.rawValue, record.resolvedType));
+      summary.valuesSet += 1;
+    } catch (err) {
+      summary.warnings.push(
+        `Failed to set value for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  for (const record of aliasRecords) {
+    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
+    const variable = variablesByCollectionAndPath.get(pathKey);
+    const collection = collectionsByName.get(record.collectionName);
+    if (!variable || !collection) continue;
+
+    const mode = collection.modes.find((m) => m.name === record.modeName);
+    if (!mode) continue;
+
+    const ref = parseAliasReference(record.rawValue, record.collectionName)!;
+    const targetCollection = collectionsByName.get(ref.collectionName)
+      ?? (await figma.variables.getLocalVariableCollectionsAsync()).find((c) => c.name === ref.collectionName);
+
+    if (!targetCollection) {
+      summary.warnings.push(
+        `Could not resolve alias for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}): collection "${ref.collectionName}" not found.`
+      );
+      continue;
+    }
+
+    const targetModeName = getMatchingModeName(ref.modeName, targetCollection);
+    const targetModeId = targetCollection.modes.find((m) => m.name === targetModeName)?.modeId;
+
+    const targetVariables = await Promise.all(
+      targetCollection.variableIds.map((id) => figma.variables.getVariableByIdAsync(id))
+    );
+    const targetVariable = targetVariables.find((v) => v !== null && v.name === ref.path) as Variable | undefined;
+
+    if (!targetVariable || !targetModeId) {
+      summary.warnings.push(
+        `Could not resolve alias for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}): variable "${ref.path}" not found in "${ref.collectionName}".`
+      );
+      continue;
+    }
+
+    try {
+      variable.setValueForMode(mode.modeId, figma.variables.createVariableAlias(targetVariable));
+      summary.aliasesResolved += 1;
+      summary.valuesSet += 1;
+    } catch (err) {
+      summary.warnings.push(
+        `Failed to set alias for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  return summary;
+}

--- a/src/utils/importJSON.ts
+++ b/src/utils/importJSON.ts
@@ -1,5 +1,4 @@
 import { cssColorToRgba } from "./color";
-import { getMatchingModeName } from "./variableUtils";
 import type { ImportSummary } from "../types.d";
 
 const validTypes = new Set(["COLOR", "FLOAT", "BOOLEAN", "STRING"]);
@@ -121,36 +120,98 @@ function collectRecords(rawFiles: string[]): { records: ImportRecord[]; warnings
   return { records, warnings };
 }
 
-interface AliasReference {
+/**
+ * True if this is the plugin's `$.Collection.Mode.path` alias-reference
+ * convention (as opposed to a literal value or `"_unlinked"`).
+ */
+function isAliasValue(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith("$.") && value !== "_unlinked";
+}
+
+interface AliasTarget {
   collectionName: string;
   modeName: string;
   path: string;
 }
 
 /**
- * Parses a `$.Collection.Mode.path` (or same-collection `$..Mode.path`)
- * alias-reference string back into its parts. Returns `null` for anything
- * that isn't the alias-reference convention (including `"_unlinked"`).
+ * Splits `body` on the longest name in `names` that it starts with, as
+ * `"<name>.<rest>"`. Matching against known names (rather than blindly
+ * splitting on every "." ) is what lets collection/mode/group names that
+ * themselves contain literal dots round-trip correctly.
  */
-export function parseAliasReference(value: unknown, currentCollectionName: string): AliasReference | null {
-  if (typeof value !== "string" || !value.startsWith("$.")) {
-    return null;
+function splitOnKnownName(body: string, names: string[]): { name: string; rest: string } | undefined {
+  const sorted = [...names].sort((a, b) => b.length - a.length);
+  for (const name of sorted) {
+    if (body.startsWith(`${name}.`)) {
+      return { name, rest: body.slice(name.length + 1) };
+    }
   }
+  return undefined;
+}
 
+/**
+ * Resolves a `$.Collection.Mode.path` (or same-collection `$..Mode.path`)
+ * alias-reference string into every plausible `{collection, mode, path}`
+ * interpretation, most-specific first. The convention's own "." separator
+ * is ambiguous with a literal "." inside a collection/mode/group name (e.g.
+ * a collection named ".Brand"), so this can't be resolved by string-splitting
+ * alone — instead it's matched against the actual known collection/mode
+ * names, and the caller validates each candidate against real variables
+ * until one resolves.
+ */
+function resolveAliasCandidates(
+  value: string,
+  currentCollectionName: string,
+  collectionsByName: Map<string, VariableCollection>
+): AliasTarget[] {
   const remainder = value.slice(2);
-  const sameCollection = remainder.startsWith(".");
-  const body = sameCollection ? remainder.slice(1) : remainder;
+  const candidates: AliasTarget[] = [];
 
-  const parts = body.split(".");
-  if (sameCollection) {
-    const [modeName, ...pathParts] = parts;
-    if (!modeName || pathParts.length === 0) return null;
-    return { collectionName: currentCollectionName, modeName, path: pathParts.join("/") };
+  // Explicit "$.Collection.Mode.path" form — tried first since matching an
+  // actual known collection name is stronger evidence than the generic
+  // same-collection fallback below.
+  const collectionNames = [...collectionsByName.keys()].sort((a, b) => b.length - a.length);
+  for (const collectionName of collectionNames) {
+    if (!remainder.startsWith(`${collectionName}.`)) continue;
+    const rest = remainder.slice(collectionName.length + 1);
+    const split = splitOnKnownName(rest, collectionsByName.get(collectionName)!.modes.map((m) => m.name));
+    if (split) {
+      candidates.push({ collectionName, modeName: split.name, path: split.rest.replace(/\./g, "/") });
+    }
   }
 
-  const [collectionName, modeName, ...pathParts] = parts;
-  if (!collectionName || !modeName || pathParts.length === 0) return null;
-  return { collectionName, modeName, path: pathParts.join("/") };
+  // Same-collection "$..Mode.path" form (empty collection segment).
+  if (remainder.startsWith(".")) {
+    const currentCollection = collectionsByName.get(currentCollectionName);
+    if (currentCollection) {
+      const split = splitOnKnownName(remainder.slice(1), currentCollection.modes.map((m) => m.name));
+      if (split) {
+        candidates.push({ collectionName: currentCollectionName, modeName: split.name, path: split.rest.replace(/\./g, "/") });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * Figma treats a `.` or `_`-prefixed name segment as "private" — hidden from
+ * publishing when the file is shared as a library — for collections,
+ * variables, components, and styles alike. A collection or variable whose
+ * name (or any group segment of it) starts with either prefix is recreated
+ * on import with `hiddenFromPublishing` set, so that intent survives the
+ * round-trip rather than just looking private without actually being so.
+ */
+function hasPrivateNamingConvention(name: string): boolean {
+  return name.split("/").some((segment) => segment.startsWith(".") || segment.startsWith("_"));
+}
+
+async function findVariableByName(collection: VariableCollection, name: string): Promise<Variable | undefined> {
+  const variables = await Promise.all(
+    collection.variableIds.map((id) => figma.variables.getVariableByIdAsync(id))
+  );
+  return variables.find((v): v is Variable => v !== null && v.name === name);
 }
 
 function parseLiteralValue(
@@ -227,6 +288,9 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
     let isNewCollection = false;
     if (!collection) {
       collection = figma.variables.createVariableCollection(collectionName);
+      if (hasPrivateNamingConvention(collectionName)) {
+        collection.hiddenFromPublishing = true;
+      }
       collectionsByName.set(collectionName, collection);
       summary.collectionsCreated += 1;
       isNewCollection = true;
@@ -261,7 +325,7 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
   const seenPaths = new Set<string>();
 
   for (const record of records) {
-    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
+    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
     if (seenPaths.has(pathKey)) continue;
     seenPaths.add(pathKey);
 
@@ -269,10 +333,7 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
     if (!collection) continue;
 
     const varName = record.pathParts.join("/");
-    const existingVariables = await Promise.all(
-      collection.variableIds.map((id) => figma.variables.getVariableByIdAsync(id))
-    );
-    const existingVariable = existingVariables.find((v) => v !== null && v.name === varName) as Variable | undefined;
+    const existingVariable = await findVariableByName(collection, varName);
 
     let variable: Variable;
     if (existingVariable) {
@@ -286,6 +347,9 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
       summary.variablesUpdated += 1;
     } else {
       variable = figma.variables.createVariable(varName, collection, record.resolvedType);
+      if (hasPrivateNamingConvention(varName)) {
+        variable.hiddenFromPublishing = true;
+      }
       summary.variablesCreated += 1;
     }
 
@@ -307,12 +371,12 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
       );
       continue;
     }
-    if (parseAliasReference(record.rawValue, record.collectionName)) {
+    if (isAliasValue(record.rawValue)) {
       aliasRecords.push(record);
       continue;
     }
 
-    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
+    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
     const variable = variablesByCollectionAndPath.get(pathKey);
     const collection = collectionsByName.get(record.collectionName);
     if (!variable || !collection) continue;
@@ -331,7 +395,7 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
   }
 
   for (const record of aliasRecords) {
-    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
+    const pathKey = `${record.collectionName} ${record.pathParts.join("/")}`;
     const variable = variablesByCollectionAndPath.get(pathKey);
     const collection = collectionsByName.get(record.collectionName);
     if (!variable || !collection) continue;
@@ -339,34 +403,30 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
     const mode = collection.modes.find((m) => m.name === record.modeName);
     if (!mode) continue;
 
-    const ref = parseAliasReference(record.rawValue, record.collectionName)!;
-    const targetCollection = collectionsByName.get(ref.collectionName)
-      ?? (await figma.variables.getLocalVariableCollectionsAsync()).find((c) => c.name === ref.collectionName);
+    const candidates = resolveAliasCandidates(record.rawValue as string, record.collectionName, collectionsByName);
 
-    if (!targetCollection) {
-      summary.warnings.push(
-        `Could not resolve alias for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}): collection "${ref.collectionName}" not found.`
-      );
-      continue;
+    let resolvedTarget: { modeId: string; variable: Variable } | undefined;
+    for (const candidate of candidates) {
+      const targetCollection = collectionsByName.get(candidate.collectionName);
+      const targetModeId = targetCollection?.modes.find((m) => m.name === candidate.modeName)?.modeId;
+      if (!targetCollection || !targetModeId) continue;
+
+      const targetVariable = await findVariableByName(targetCollection, candidate.path);
+      if (targetVariable) {
+        resolvedTarget = { modeId: targetModeId, variable: targetVariable };
+        break;
+      }
     }
 
-    const targetModeName = getMatchingModeName(ref.modeName, targetCollection);
-    const targetModeId = targetCollection.modes.find((m) => m.name === targetModeName)?.modeId;
-
-    const targetVariables = await Promise.all(
-      targetCollection.variableIds.map((id) => figma.variables.getVariableByIdAsync(id))
-    );
-    const targetVariable = targetVariables.find((v) => v !== null && v.name === ref.path) as Variable | undefined;
-
-    if (!targetVariable || !targetModeId) {
+    if (!resolvedTarget) {
       summary.warnings.push(
-        `Could not resolve alias for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}): variable "${ref.path}" not found in "${ref.collectionName}".`
+        `Could not resolve alias for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}): value "${record.rawValue}" did not match any known collection/mode/variable.`
       );
       continue;
     }
 
     try {
-      variable.setValueForMode(mode.modeId, figma.variables.createVariableAlias(targetVariable));
+      variable.setValueForMode(mode.modeId, figma.variables.createVariableAlias(resolvedTarget.variable));
       summary.aliasesResolved += 1;
       summary.valuesSet += 1;
     } catch (err) {

--- a/src/views/ImportJSON.tsx
+++ b/src/views/ImportJSON.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Flex, Text, Button } from "figma-kit";
+import { PluginDialogShell } from "../components/PluginDialogShell";
+import { ExportLayout } from "../components/ExportLayout";
+import { FileImportInput } from "../components/FileImportInput";
+import { ImportOptions } from "../components/ImportOptions";
+import { ConfirmReplaceDialog } from "../components/ConfirmReplaceDialog";
+import { ImportSummaryPanel } from "../components/ImportSummaryPanel";
+import { useImportData } from "../hooks/useImportData";
+
+interface ImportJSONProps {
+    editorType?: string;
+}
+
+/**
+ * JSON import view: pick a previously-exported VarVar JSON file (or files),
+ * optionally replace all existing variables, and recreate collections,
+ * modes, variables and linked-variable references in the document.
+ */
+export const ImportJSON: React.FC<ImportJSONProps> = ({ editorType = "" }) => {
+    const {
+        fileNames,
+        fileContents,
+        setFiles,
+        replaceExisting,
+        setReplaceExisting,
+        confirmDialogOpen,
+        setConfirmDialogOpen,
+        isImporting,
+        importSummary,
+        importError,
+        handleImportClick,
+        handleConfirmReplace
+    } = useImportData();
+
+    const formControls = (
+        <>
+            <Flex direction="column" gap="2">
+                <Text size="large" weight="strong">Import from JSON</Text>
+                <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
+                    Import a JSON file previously exported by VarVar (current or legacy
+                    format) to recreate collections, modes, variables and linked
+                    variables. CSV, CSS and JS files aren't supported for import.
+                </Text>
+            </Flex>
+
+            <FileImportInput fileNames={fileNames} onFilesSelected={setFiles} />
+
+            <ImportOptions
+                replaceExisting={replaceExisting}
+                onReplaceExistingChange={setReplaceExisting}
+            />
+
+            <Button
+                variant="primary"
+                fullWidth={true}
+                size="medium"
+                disabled={fileContents.length === 0 || isImporting}
+                onClick={handleImportClick}
+            >
+                {isImporting ? "Importing…" : "Import Variables"}
+            </Button>
+
+            {importError && (
+                <Flex style={{
+                    padding: "0.5rem",
+                    border: "1px solid var(--figma-color-border-danger-strong)",
+                    borderRadius: "4px",
+                    backgroundColor: "var(--figma-color-bg-danger)",
+                }}>
+                    <Text style={{ color: 'var(--figma-color-text-ondanger)' }}>
+                        {importError}
+                    </Text>
+                </Flex>
+            )}
+        </>
+    );
+
+    const preview = importSummary ? (
+        <ImportSummaryPanel summary={importSummary} editorType={editorType} />
+    ) : null;
+
+    return (
+        <PluginDialogShell>
+            <ExportLayout
+                editorType={editorType}
+                children={formControls}
+                preview={preview}
+            />
+
+            <ConfirmReplaceDialog
+                open={confirmDialogOpen}
+                onOpenChange={setConfirmDialogOpen}
+                onConfirm={handleConfirmReplace}
+            />
+        </PluginDialogShell>
+    );
+};


### PR DESCRIPTION
## Summary
- Adds a JSON import path (menu: **Plugins → VarVar → Import…**) that recreates collections, modes, and variables from a previously exported VarVar JSON file — current (v3.x), legacy (v2.x), and plain-DTCG token files are all accepted.
- Resolves the plugin's `$.Collection.Mode.path` alias convention back into real Figma variable aliases, using name-aware matching (not a naive string-split) so collection/mode/group names containing a literal `.` — including Figma's own `.`/`_` "private/hidden from publishing" naming convention — round-trip correctly. Newly created private-named collections/variables get `hiddenFromPublishing` set to match.
- Optional **Replace existing variables** toggle (deletes all local variable collections before importing) gated by a persistent warning plus an `AlertDialog` confirmation — guarded so nothing is deleted if the selected file(s) turn out to have zero importable variables.
- Import report/warnings panel reuses the export views' right-hand preview-panel layout; warnings render as `Summary`/`Detail` in a translucent, theme-safe style; file picker is a custom figma-kit-styled button (figma-kit has no file input).
- Docs updated: README, CONTRIBUTING.md, `.figma/publishing-info.md`.