### PR TITLE
Syntax highlighting + fixed code preview scrolling

### DIFF
--- a/src/components/ExportLayout.tsx
+++ b/src/components/ExportLayout.tsx
@@ -22,16 +22,18 @@ export const ExportLayout: React.FC<ExportLayoutProps> = ({
     if (isDesignMode) {
         // Horizontal layout for Design mode
         return (
-            <Flex 
-                direction="row" 
+            <Flex
+                direction="row"
                 gap="4"
                 style={{
                     position: "relative",
+                    flex: 1,
+                    minHeight: 0,
                 }}
             >
                 {/* Form controls on the left */}
-                <Flex 
-                    direction="column" 
+                <Flex
+                    direction="column"
                     gap="4"
                     style={{
                         flex: "1 1 200px",
@@ -44,7 +46,7 @@ export const ExportLayout: React.FC<ExportLayoutProps> = ({
                 >
                     {children}
                 </Flex>
-                
+
                 {/* Preview on the right - takes remaining space and full height */}
                 {preview}
             </Flex>
@@ -53,7 +55,7 @@ export const ExportLayout: React.FC<ExportLayoutProps> = ({
 
     // Vertical layout for Dev mode (default)
     return (
-        <Flex direction="column" gap="4">
+        <Flex direction="column" gap="4" style={{ flex: 1, minHeight: 0 }}>
             {children}
             {preview}
         </Flex>

--- a/src/components/OutputPreview.tsx
+++ b/src/components/OutputPreview.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from "react";
 import { Flex, Text, Button, Link } from "figma-kit";
 import { copyToClipboard } from "../utils/clipboard";
-import { ExportFile } from "../types.d";
+import { renderCodeLines } from "../utils/highlightCode";
+import { ExportFile, OutputFormats } from "../types.d";
 
 interface OutputPreviewProps {
     exportedData: string;
     files?: ExportFile[] | null;
     usedExtendedCollections?: boolean;
     editorType?: string;
+    format?: OutputFormats;
     onSelectToCopy: () => void;
 }
 
@@ -20,6 +22,7 @@ export const OutputPreview: React.FC<OutputPreviewProps> = ({
     files,
     usedExtendedCollections = false,
     editorType = 'dev',
+    format,
     onSelectToCopy
 }) => {
     const [copyStatus, setCopyStatus] = useState<'idle' | 'success' | 'error'>('idle');
@@ -45,7 +48,16 @@ export const OutputPreview: React.FC<OutputPreviewProps> = ({
     if (!activeContent) return null;
 
     return (
-        <Flex direction="column" gap="2" style={{ flex: "2 0 300px", maxWidth: editorType === 'design' ? "454px" : undefined }}>
+        <Flex
+            direction="column"
+            gap="2"
+            style={{
+                flex: "2 1 300px",
+                minWidth: 0,
+                minHeight: 0,
+                maxWidth: editorType === 'design' ? "454px" : "100%",
+            }}
+        >
             <Text>Code Preview</Text>
             {usedExtendedCollections && (
                 <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
@@ -78,11 +90,16 @@ export const OutputPreview: React.FC<OutputPreviewProps> = ({
                     borderRadius: 4,
                     padding: 8,
                     backgroundColor: 'rgba(0,0,0,.25)',
+                    minWidth: 0,
+                    maxWidth: '100%',
+                    boxSizing: 'border-box',
+                    flex: '1 1 auto',
+                    minHeight: 0,
                 }}
             >
-                <Flex direction="column">
-                    <Flex 
-                        direction="row" 
+                <Flex direction="column" style={{ minWidth: 0, maxWidth: '100%', flex: 1, minHeight: 0 }}>
+                    <Flex
+                        direction="row"
                         gap="2"
                         style={{
                             alignSelf: 'end',
@@ -97,7 +114,7 @@ export const OutputPreview: React.FC<OutputPreviewProps> = ({
                             onClick={handleCopy}
                             disabled={copyStatus !== 'idle'}
                         >
-                            {copyStatus === 'success' ? '✓ Copied!' : 
+                            {copyStatus === 'success' ? '✓ Copied!' :
                              copyStatus === 'error' ? '✗ Failed' : 'Copy'}
                         </Button>
                         <Button
@@ -107,14 +124,31 @@ export const OutputPreview: React.FC<OutputPreviewProps> = ({
                             Select Result
                         </Button>
                     </Flex>
-                    <Text style={{ marginTop: '-2rem' }}>
+                    <Text
+                        style={{
+                            marginTop: '-2rem',
+                            display: 'flex',
+                            flex: 1,
+                            minHeight: 0,
+                        }}
+                    >
                         <pre
+                            key={activeFileIndex}
                             id="varvar-exported-output"
-                            style={{ overflow: 'auto' }}
+                            style={{
+                                flex: 1,
+                                minHeight: 0,
+                                overflowX: 'auto',
+                                overflowY: 'auto',
+                                maxWidth: '100%',
+                                boxSizing: 'border-box',
+                                margin: 0,
+                            }}
                             contentEditable
                             spellCheck="false"
+                            suppressContentEditableWarning
                         >
-                            {activeContent.toString()}
+                            {renderCodeLines(activeContent.toString(), format)}
                         </pre>
                     </Text>
                 </Flex>

--- a/src/components/PluginDialogShell.tsx
+++ b/src/components/PluginDialogShell.tsx
@@ -16,17 +16,19 @@ export const PluginDialogShell: React.FC<PluginDialogShellProps> = ({
     showFooter = true 
 }) => {
     return (
-        <Flex 
-            direction="column" 
+        <Flex
+            direction="column"
             gap="4"
-            justify="between"
             style={{
                 padding: "1rem",
                 boxSizing: "border-box",
                 minHeight: "100%",
+                flex: 1,
             }}
         >
-            {children}
+            <Flex direction="column" gap="4" style={{ flex: 1, minHeight: 0 }}>
+                {children}
+            </Flex>
             {showFooter && <Footer />}
         </Flex>
     );

--- a/src/index.html
+++ b/src/index.html
@@ -5,9 +5,40 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>VarVar Figma Plugin</title>
     <style>
-      html { height: 100%; }
-      body { margin: 0; padding: 0; }
-      #root { min-height: 100vh; }
+      html {
+        height: 100%;
+        scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+        scrollbar-width: thin;
+      }
+      body { margin: 0; padding: 0; max-width: 100%; overflow-x: hidden; }
+      html::-webkit-scrollbar,
+      body::-webkit-scrollbar {
+        width: 10px;
+        height: 10px;
+      }
+      html::-webkit-scrollbar-track,
+      body::-webkit-scrollbar-track {
+        background: transparent;
+      }
+      html::-webkit-scrollbar-thumb,
+      body::-webkit-scrollbar-thumb {
+        background-color: rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        border: 2px solid transparent;
+        background-clip: padding-box;
+      }
+      html::-webkit-scrollbar-thumb:hover,
+      body::-webkit-scrollbar-thumb:hover {
+        background-color: rgba(255, 255, 255, 0.4);
+      }
+      #root {
+        min-height: 100vh;
+        width: 100%;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+      }
+      #root > * { flex: 1; min-height: 0; }
     </style>
   </head>
   <body>

--- a/src/styles/highlightCode.css
+++ b/src/styles/highlightCode.css
@@ -1,0 +1,91 @@
+.vv-tok-key,
+.vv-tok-property,
+.vv-tok-selector {
+    color: #9cdcfe;
+}
+
+.vv-tok-string {
+    color: #ce9178;
+}
+
+.vv-tok-number {
+    color: #b5cea8;
+}
+
+.vv-tok-boolean {
+    color: #569cd6;
+}
+
+.vv-tok-keyword,
+.vv-tok-atrule {
+    color: #c586c0;
+}
+
+.vv-tok-comment {
+    color: #6a9955;
+    font-style: italic;
+}
+
+.vv-tok-punctuation {
+    color: var(--figma-color-text-secondary);
+}
+
+.vv-tok-hex {
+    color: #4fc1ff;
+}
+
+.vv-tok-function {
+    color: #dcdcaa;
+}
+
+.vv-tok-identifier {
+    color: inherit;
+}
+
+.vv-line {
+    display: flex;
+    white-space: pre;
+}
+
+.vv-line-number {
+    flex: none;
+    min-width: 2.5em;
+    margin-right: 1em;
+    padding-right: 0.25em;
+    text-align: right;
+    color: var(--figma-color-text-tertiary, var(--figma-color-text-secondary));
+    opacity: 0.5;
+    user-select: none;
+    -webkit-user-select: none;
+    cursor: default;
+}
+
+.vv-line-content {
+    flex: 1 1 auto;
+    white-space: pre;
+}
+
+#varvar-exported-output {
+    scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+    scrollbar-width: thin;
+}
+
+#varvar-exported-output::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+#varvar-exported-output::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+#varvar-exported-output::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.25);
+    border-radius: 8px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+}
+
+#varvar-exported-output::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(255, 255, 255, 0.4);
+}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import ReactDOM from "react-dom/client";
 import "figma-kit/styles.css";
+import "./styles/highlightCode.css";
 import { PluginCommands, MessageTypes, PluginMessage } from "./types.d";
 import { ExportView } from "./views/ExportView";
 import { ExportJSON } from "./views/ExportJSON";

--- a/src/utils/highlightCode.tsx
+++ b/src/utils/highlightCode.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { OutputFormats } from "../types.d";
+
+type TokenRule = {
+    type: string;
+    regex: RegExp;
+};
+
+type Token = {
+    type: string | null;
+    text: string;
+};
+
+const JSON_RULES: TokenRule[] = [
+    { type: "key", regex: /"(?:\\.|[^"\\])*"(?=\s*:)/y },
+    { type: "string", regex: /"(?:\\.|[^"\\])*"/y },
+    { type: "number", regex: /-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/y },
+    { type: "boolean", regex: /\b(?:true|false|null)\b/y },
+    { type: "punctuation", regex: /[{}[\]:,]/y },
+];
+
+const CSS_RULES: TokenRule[] = [
+    { type: "comment", regex: /\/\*[\s\S]*?\*\//y },
+    { type: "string", regex: /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/y },
+    { type: "hex", regex: /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})\b/y },
+    { type: "function", regex: /[-a-zA-Z_][-a-zA-Z0-9_]*(?=\()/y },
+    { type: "selector", regex: /[.#]?[-\w]+(?=\s*\{)/y },
+    { type: "property", regex: /(?:--)?[-a-zA-Z0-9_]+(?=\s*:)/y },
+    // Catch-all for identifiers (custom property names in var(...), keywords
+    // like `red` or `flex`, etc.) so a trailing digit - e.g. the `2` in
+    // `--headline-2` - isn't matched on its own by the number rule below.
+    { type: "identifier", regex: /-{0,2}[a-zA-Z_][-a-zA-Z0-9_]*/y },
+    { type: "number", regex: /-?\b\d+(?:\.\d+)?(?:px|rem|em|%|deg|s|ms|vh|vw)?\b/y },
+    { type: "punctuation", regex: /[{}();:,]/y },
+    { type: "atrule", regex: /@[-a-zA-Z]+/y },
+];
+
+const JS_RULES: TokenRule[] = [
+    { type: "comment", regex: /\/\/.*|\/\*[\s\S]*?\*\//y },
+    { type: "string", regex: /`(?:\\.|[^`\\])*`|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/y },
+    {
+        type: "keyword",
+        regex: /\b(?:const|let|var|function|return|if|else|for|while|import|export|from|default|type|interface|enum|as|of|in|new|typeof|extends|implements|class|public|private|readonly|void|async|await)\b/y,
+    },
+    { type: "boolean", regex: /\b(?:true|false|null|undefined)\b/y },
+    { type: "number", regex: /-?\b\d+(?:\.\d+)?\b/y },
+    { type: "punctuation", regex: /[{}[\]().,;:]/y },
+];
+
+const CSV_RULES: TokenRule[] = [
+    { type: "string", regex: /"(?:\\.|[^"\\])*"/y },
+    { type: "punctuation", regex: /,/y },
+];
+
+function rulesForLanguage(language: string): TokenRule[] {
+    switch (language) {
+        case OutputFormats.JSON:
+            return JSON_RULES;
+        case OutputFormats.CSS:
+            return CSS_RULES;
+        case OutputFormats.JS:
+        case OutputFormats.TS:
+            return JS_RULES;
+        case OutputFormats.CSV:
+            return CSV_RULES;
+        default:
+            return [];
+    }
+}
+
+/**
+ * Tokenizes `code` against `rules` (sticky regex, tried in order at each
+ * position, so more specific patterns must come first - e.g. JSON "key"
+ * before generic "string"). Unrecognized characters come back as `type: null`
+ * runs.
+ */
+function tokenize(code: string, language: string): Token[] {
+    const rules = rulesForLanguage(language);
+    if (rules.length === 0) return [{ type: null, text: code }];
+
+    const tokens: Token[] = [];
+    let pos = 0;
+    let plainStart = 0;
+
+    while (pos < code.length) {
+        let matched = false;
+
+        for (const rule of rules) {
+            rule.regex.lastIndex = pos;
+            const match = rule.regex.exec(code);
+            if (match && match.index === pos) {
+                if (plainStart < pos) {
+                    tokens.push({ type: null, text: code.slice(plainStart, pos) });
+                }
+                tokens.push({ type: rule.type, text: match[0] });
+                pos += match[0].length;
+                plainStart = pos;
+                matched = true;
+                break;
+            }
+        }
+
+        if (!matched) pos += 1;
+    }
+
+    if (plainStart < code.length) {
+        tokens.push({ type: null, text: code.slice(plainStart) });
+    }
+
+    return tokens;
+}
+
+/**
+ * Splits a flat token stream on newlines into per-line token groups. A token
+ * spanning multiple lines (e.g. a block comment) keeps its type on every
+ * line it touches.
+ */
+function splitTokensIntoLines(tokens: Token[]): Token[][] {
+    const lines: Token[][] = [[]];
+
+    for (const token of tokens) {
+        const parts = token.text.split("\n");
+        parts.forEach((part, index) => {
+            if (index > 0) lines.push([]);
+            if (part.length > 0) lines[lines.length - 1].push({ type: token.type, text: part });
+        });
+    }
+
+    return lines;
+}
+
+/**
+ * Renders `code` as numbered, syntax-highlighted lines. Line numbers are
+ * marked non-editable and non-selectable (`user-select: none` in
+ * highlightCode.css) so they never end up in a copy/paste of the code.
+ */
+export function renderCodeLines(code: string, language?: string): React.ReactNode {
+    const tokens = language ? tokenize(code, language) : [{ type: null, text: code }];
+    const lines = splitTokensIntoLines(tokens);
+
+    return (
+        <>
+            {lines.map((line, lineIndex) => (
+                <div className="vv-line" key={lineIndex}>
+                    <span className="vv-line-number" contentEditable={false}>
+                        {lineIndex + 1}
+                    </span>
+                    <span className="vv-line-content">
+                        {line.map((token, tokenIndex) =>
+                            token.type ? (
+                                <span key={tokenIndex} className={`vv-tok vv-tok-${token.type}`}>
+                                    {token.text}
+                                </span>
+                            ) : (
+                                token.text
+                            )
+                        )}
+                    </span>
+                </div>
+            ))}
+        </>
+    );
+}

--- a/src/views/ExportCSS.tsx
+++ b/src/views/ExportCSS.tsx
@@ -68,6 +68,7 @@ export const ExportCSS: React.FC<ExportCSSProps> = ({ editorType = "" }) => {
             exportedData={exportedData}
             usedExtendedCollections={usedExtendedCollections}
             editorType={editorType}
+            format={format}
             onSelectToCopy={handleSelectToCopy}
         />
     ) : null;

--- a/src/views/ExportCSV.tsx
+++ b/src/views/ExportCSV.tsx
@@ -70,6 +70,7 @@ export const ExportCSV: React.FC<ExportCSVProps> = ({ editorType = "" }) => {
             exportedData={exportedData}
             usedExtendedCollections={usedExtendedCollections}
             editorType={editorType}
+            format={format}
             onSelectToCopy={handleSelectToCopy}
         />
     ) : null;

--- a/src/views/ExportJS.tsx
+++ b/src/views/ExportJS.tsx
@@ -68,6 +68,7 @@ export const ExportJS: React.FC<ExportJSProps> = ({ editorType = "" }) => {
             exportedData={exportedData}
             usedExtendedCollections={usedExtendedCollections}
             editorType={editorType}
+            format={format}
             onSelectToCopy={handleSelectToCopy}
         />
     ) : null;

--- a/src/views/ExportJSON.tsx
+++ b/src/views/ExportJSON.tsx
@@ -70,6 +70,7 @@ export const ExportJSON: React.FC<ExportJSONProps> = ({ editorType = "" }) => {
             files={exportedFiles}
             usedExtendedCollections={usedExtendedCollections}
             editorType={editorType}
+            format={format}
             onSelectToCopy={handleSelectToCopy}
         />
     ) : null;

--- a/src/views/ExportView.tsx
+++ b/src/views/ExportView.tsx
@@ -121,9 +121,10 @@ export const ExportView: React.FC<ExportViewProps> = ({ editorType = "" }) => {
     );
 
     const preview = seeOutput && exportedData ? (
-        <OutputPreview 
+        <OutputPreview
             exportedData={exportedData}
             editorType={editorType}
+            format={format}
             onSelectToCopy={handleSelectToCopy}
         />
     ) : null;


### PR DESCRIPTION
## Summary
- Colour-codes the exported code preview for JSON, CSS, JS, TS and CSV, with per-line line numbers (excluded from copy/selection via `contentEditable={false}` + `user-select: none`).
- Reworks the dialog shell (`PluginDialogShell` → `ExportLayout` → `OutputPreview`) into a proper flex chain so the code box grows to fill whatever vertical space is available and only it scrolls, instead of the fixed `50vh` cap or the whole plugin window overflowing horizontally.
- Restyles scrollbars (both the plugin window and the code box) with a transparent track and a thin translucent thumb.

## Test plan
- [x] `npm run tsc`
- [x] `npm run build`
- [x] Manual check in Figma: export JSON/CSS/JS/CSV, confirm colours, line numbers, scrollbars, and that resizing the plugin window keeps the code box contained