### PR TITLE
Import: replace 'replace existing' toggle with 4 reconciliation modes

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -9,7 +9,7 @@ import { toLegacyJSON } from "./utils/legacyJsonConverter";
 import { toLegacyCSV } from "./utils/legacyCsvConverter";
 import { toLegacyJS } from "./utils/legacyJsConverter";
 import { importVariables } from "./utils/importJSON";
-import { OutputFormats, MessageTypes, PluginCommands, PluginMessage, ExportFile } from "./types.d";
+import { OutputFormats, MessageTypes, PluginCommands, PluginMessage, ExportFile, ImportMode } from "./types.d";
 
 figma.showUI(__html__, { width: 800, height: 500, themeColors: true });
 
@@ -116,9 +116,9 @@ async function handleExport(format: OutputFormats, useLinkedVarRowAndColPos: boo
  * collections, modes, variables and their values (including linked variables)
  * in the current document.
  */
-async function handleImport(importFiles: string[], replaceExisting: boolean) {
+async function handleImport(importFiles: string[], importMode: ImportMode) {
     try {
-        const importSummary = await importVariables(importFiles, replaceExisting);
+        const importSummary = await importVariables(importFiles, importMode);
 
         figma.ui.postMessage({
             type: MessageTypes.IMPORT_SUCCESS_RESULT,
@@ -158,7 +158,7 @@ figma.ui.onmessage = async (msg: PluginMessage) => {
 
         case MessageTypes.IMPORT_REQUEST:
             if (msg.importFiles && msg.importFiles.length > 0) {
-                await handleImport(msg.importFiles, msg.replaceExisting || false);
+                await handleImport(msg.importFiles, msg.importMode || ImportMode.MERGE);
             } else {
                 console.error('Import request missing files');
             }

--- a/src/components/ConfirmReplaceDialog.tsx
+++ b/src/components/ConfirmReplaceDialog.tsx
@@ -1,38 +1,63 @@
 import React from "react";
 import { AlertDialog, Button } from "figma-kit";
+import { ImportMode } from "../types.d";
 
 interface ConfirmReplaceDialogProps {
     open: boolean;
+    mode: ImportMode;
     onOpenChange: (open: boolean) => void;
     onConfirm: () => void;
 }
 
 /**
- * Confirmation gate for the destructive "replace existing variables" import
- * path. Shown only when the user triggers an import with that toggle on.
+ * Confirmation gate for the two destructive import modes (Sync and Clean).
+ * Merge and Update only never show this — they never delete anything.
  */
 export const ConfirmReplaceDialog: React.FC<ConfirmReplaceDialogProps> = ({
     open,
+    mode,
     onOpenChange,
     onConfirm
 }) => {
+    const isClean = mode === ImportMode.CLEAN;
+
     return (
         <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
             <AlertDialog.Content>
-                <AlertDialog.Title>Replace existing variables?</AlertDialog.Title>
+                <AlertDialog.Title>
+                    {isClean ? "Delete all and import?" : "Merge and delete missing?"}
+                </AlertDialog.Title>
                 <AlertDialog.Description>
-                    This deletes <strong>all</strong> existing local variable collections
-                    in this file — not just the ones named in the JSON you're importing —
-                    and then recreates everything from the file. This can&apos;t be undone
-                    through the plugin; Figma&apos;s own undo (Cmd/Ctrl+Z) right afterwards
-                    may still work.
+                    {isClean ? (
+                        <>
+                            This deletes <strong>all</strong> existing local variable
+                            collections in this file — not just the ones named in the JSON
+                            you&apos;re importing — and then recreates everything from the
+                            file. Every existing component link to a variable is broken,
+                            even where the recreated variable matches exactly. This
+                            can&apos;t be undone through the plugin; Figma&apos;s own undo
+                            (Cmd/Ctrl+Z) right afterwards may still work.
+                        </>
+                    ) : (
+                        <>
+                            This creates or updates collections, modes and variables from
+                            the file, then deletes <strong>anything else in this
+                            document</strong> that isn&apos;t present in the file —
+                            including whole collections the file doesn&apos;t mention.
+                            Any component linked to a deleted variable loses that link.
+                            This can&apos;t be undone through the plugin; Figma&apos;s own
+                            undo (Cmd/Ctrl+Z) right afterwards may still work.
+                        </>
+                    )}
                 </AlertDialog.Description>
                 <AlertDialog.Actions>
                     <AlertDialog.Cancel>
                         <Button variant="secondary">Cancel</Button>
                     </AlertDialog.Cancel>
                     <AlertDialog.Action onClick={onConfirm}>
-                        <Button variant="destructive">Delete and import</Button>
+                        <Button variant="destructive">
+                            {isClean ? "Delete and import" : "Merge and delete"}
+                        </Button>
                     </AlertDialog.Action>
                 </AlertDialog.Actions>
             </AlertDialog.Content>

--- a/src/components/ImportOptions.tsx
+++ b/src/components/ImportOptions.tsx
@@ -1,19 +1,24 @@
 import React from "react";
-import { Flex, Switch, Label, Text } from "figma-kit";
+import { Flex, RadioGroup, Label, Text } from "figma-kit";
+import { ImportMode } from "../types.d";
 
 interface ImportOptionsProps {
-    replaceExisting: boolean;
-    onReplaceExistingChange: (replaceExisting: boolean) => void;
+    importMode: ImportMode;
+    onImportModeChange: (importMode: ImportMode) => void;
 }
 
 /**
- * Import-specific options: the "replace existing variables" toggle. This is
- * destructive (wipes every local variable collection before importing), so
- * it defaults to off and is always followed by a confirmation dialog.
+ * Import-specific options: how to reconcile the imported file against
+ * existing local variables. Merge and Update only never delete anything, so
+ * existing component bindings are never broken. Sync deletes only what has no
+ * match in the file (matches are updated in place, keeping their bindings);
+ * Clean deletes everything up front and recreates it, so even variables that
+ * match the file exactly lose their bindings. Both show a warning and (in the
+ * parent view) require confirmation before running.
  */
 export const ImportOptions: React.FC<ImportOptionsProps> = ({
-    replaceExisting,
-    onReplaceExistingChange
+    importMode,
+    onImportModeChange
 }) => {
     return (
         <Flex gap="2" direction="column">
@@ -21,27 +26,72 @@ export const ImportOptions: React.FC<ImportOptionsProps> = ({
                 Options
             </Label>
 
-            <Flex gap="2">
-                <Switch
-                    id="varvar-import-replace-existing"
-                    onCheckedChange={onReplaceExistingChange}
-                    checked={replaceExisting}
-                    style={{ flexShrink: 0 }}
-                />
-                <Label htmlFor="varvar-import-replace-existing">
-                    Replace existing variables
-                </Label>
-                <span title="Deletes every existing local variable collection in this file before importing, so the result matches the JSON exactly. This is not limited to collections named in the file — everything is wiped first. You'll be asked to confirm." style={{ backgroundColor: 'var(--figma-color-text-secondary)', fontFamily: 'sans-serif', cursor: 'help', userSelect: 'none', color: 'var(--figma-color-text-secondary-inverse)', borderRadius: '50%', padding: '1px', fontSize: '.6em', width: '1em', height: '1em', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>?</span>
-            </Flex>
+            <RadioGroup.Root
+                orientation="vertical"
+                value={importMode}
+                onValueChange={(value) => onImportModeChange(value as ImportMode)}
+            >
+                <RadioGroup.Label>
+                    <RadioGroup.Item value={ImportMode.MERGE} />
+                    Merge
+                </RadioGroup.Label>
+                <RadioGroup.Label>
+                    <RadioGroup.Item value={ImportMode.UPDATE_ONLY} />
+                    Update only
+                </RadioGroup.Label>
+                <RadioGroup.Label>
+                    <RadioGroup.Item value={ImportMode.SYNC} />
+                    Merge and delete anything not in the file
+                </RadioGroup.Label>
+                <RadioGroup.Label>
+                    <RadioGroup.Item value={ImportMode.CLEAN} />
+                    Clean import (delete everything first)
+                </RadioGroup.Label>
+            </RadioGroup.Root>
 
-            {replaceExisting && (
+            {importMode === ImportMode.MERGE && (
+                <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
+                    Creates missing collections, modes and variables, and updates any
+                    that already match by name. Nothing existing is ever deleted, so
+                    existing component links are never broken.
+                </Text>
+            )}
+
+            {importMode === ImportMode.UPDATE_ONLY && (
+                <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
+                    Only updates variables, modes and collections that already exist
+                    locally and are also present in the file. Nothing is created and
+                    nothing is deleted.
+                </Text>
+            )}
+
+            {importMode === ImportMode.SYNC && (
                 <Flex style={{
                     padding: "0.5rem",
                     borderRadius: "4px",
                     backgroundColor: "rgba(234, 179, 8, 0.15)",
                 }}>
                     <Text weight="strong" style={{ color: 'var(--figma-color-text)' }}>
-                        Warning: this deletes all existing variables before importing
+                        Warning: after merging, anything in this document not present in
+                        the file is deleted — including whole collections the file
+                        doesn&apos;t mention. Only variables with no match in the file are
+                        deleted; components using a variable that's also in the file keep
+                        their link, since that variable is updated in place, not deleted.
+                    </Text>
+                </Flex>
+            )}
+
+            {importMode === ImportMode.CLEAN && (
+                <Flex style={{
+                    padding: "0.5rem",
+                    borderRadius: "4px",
+                    backgroundColor: "rgba(234, 179, 8, 0.15)",
+                }}>
+                    <Text weight="strong" style={{ color: 'var(--figma-color-text)' }}>
+                        Warning: this deletes every existing local variable collection —
+                        not just the ones named in the file — before importing. Every
+                        variable is recreated from scratch, so every existing component
+                        link is broken, even for variables that match the file exactly.
                     </Text>
                 </Flex>
             )}

--- a/src/components/ImportSummaryPanel.tsx
+++ b/src/components/ImportSummaryPanel.tsx
@@ -30,12 +30,15 @@ export const ImportSummaryPanel: React.FC<ImportSummaryPanelProps> = ({ summary,
             >
                 <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
                     Collections: {summary.collectionsCreated} created, {summary.collectionsReused} reused
+                    {summary.collectionsDeleted > 0 && `, ${summary.collectionsDeleted} deleted`}
                 </Text>
                 <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
-                    Modes created: {summary.modesCreated}
+                    Modes: {summary.modesCreated} created
+                    {summary.modesDeleted > 0 && `, ${summary.modesDeleted} deleted`}
                 </Text>
                 <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
                     Variables: {summary.variablesCreated} created, {summary.variablesUpdated} updated
+                    {summary.variablesDeleted > 0 && `, ${summary.variablesDeleted} deleted`}
                 </Text>
                 <Text style={{ color: 'var(--figma-color-text-secondary)' }}>
                     Values set: {summary.valuesSet} ({summary.aliasesResolved} linked variables)

--- a/src/hooks/useImportData.ts
+++ b/src/hooks/useImportData.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect } from "react";
-import { MessageTypes, ImportSummary } from "../types.d";
+import { MessageTypes, ImportSummary, ImportMode } from "../types.d";
 
 interface UseImportDataReturn {
     fileNames: string[];
     fileContents: string[];
     setFiles: (fileNames: string[], fileContents: string[]) => void;
-    replaceExisting: boolean;
-    setReplaceExisting: (replaceExisting: boolean) => void;
+    importMode: ImportMode;
+    setImportMode: (importMode: ImportMode) => void;
     confirmDialogOpen: boolean;
     setConfirmDialogOpen: (open: boolean) => void;
     isImporting: boolean;
@@ -24,7 +24,7 @@ interface UseImportDataReturn {
 export const useImportData = (): UseImportDataReturn => {
     const [fileNames, setFileNames] = useState<string[]>([]);
     const [fileContents, setFileContents] = useState<string[]>([]);
-    const [replaceExisting, setReplaceExisting] = useState<boolean>(false);
+    const [importMode, setImportMode] = useState<ImportMode>(ImportMode.MERGE);
     const [confirmDialogOpen, setConfirmDialogOpen] = useState<boolean>(false);
     const [isImporting, setIsImporting] = useState<boolean>(false);
     const [importSummary, setImportSummary] = useState<ImportSummary | null>(null);
@@ -45,7 +45,7 @@ export const useImportData = (): UseImportDataReturn => {
             pluginMessage: {
                 type: MessageTypes.IMPORT_REQUEST,
                 importFiles: fileContents,
-                replaceExisting
+                importMode
             }
         }, "*");
     };
@@ -53,7 +53,9 @@ export const useImportData = (): UseImportDataReturn => {
     const handleImportClick = () => {
         if (fileContents.length === 0) return;
 
-        if (replaceExisting) {
+        // Only Sync and Clean ever delete anything — Merge and Update only
+        // don't need a confirmation gate.
+        if (importMode === ImportMode.SYNC || importMode === ImportMode.CLEAN) {
             setConfirmDialogOpen(true);
         } else {
             sendImportRequest();
@@ -81,8 +83,8 @@ export const useImportData = (): UseImportDataReturn => {
         fileNames,
         fileContents,
         setFiles,
-        replaceExisting,
-        setReplaceExisting,
+        importMode,
+        setImportMode,
         confirmDialogOpen,
         setConfirmDialogOpen,
         isImporting,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -111,16 +111,34 @@ export interface ExportFile {
 }
 
 /**
- * Summary of an import run: counts of what was created/reused/updated, plus
- * any non-fatal warnings (unresolved aliases, `_unlinked` entries, mode-limit
- * errors, type mismatches) collected along the way.
+ * How an import reconciles the imported file(s) against the document's
+ * existing local variable collections.
+ */
+export enum ImportMode {
+  /** Additive: create missing collections/modes/variables, update matches by name. Nothing is ever deleted. */
+  MERGE = "merge",
+  /** Touch only what already exists in both the file and the document (update values/description/scopes on matches). Nothing is created and nothing is deleted. */
+  UPDATE_ONLY = "update-only",
+  /** Merge (create + update), then delete any variable, mode, or whole collection anywhere in the document that isn't present in the imported file. */
+  SYNC = "sync",
+  /** Delete every existing local variable collection first, then import fresh — a full, clean re-sync. */
+  CLEAN = "clean",
+}
+
+/**
+ * Summary of an import run: counts of what was created/reused/updated/deleted,
+ * plus any non-fatal warnings (unresolved aliases, `_unlinked` entries,
+ * mode-limit errors, type mismatches) collected along the way.
  */
 export interface ImportSummary {
   collectionsCreated: number;
   collectionsReused: number;
+  collectionsDeleted: number;
   modesCreated: number;
+  modesDeleted: number;
   variablesCreated: number;
   variablesUpdated: number;
+  variablesDeleted: number;
   valuesSet: number;
   aliasesResolved: number;
   warnings: string[];
@@ -144,6 +162,6 @@ export interface PluginMessage {
   error?: string;
   editorType?: string;
   importFiles?: string[];
-  replaceExisting?: boolean;
+  importMode?: ImportMode;
   importSummary?: ImportSummary;
 }

--- a/src/utils/importJSON.ts
+++ b/src/utils/importJSON.ts
@@ -1,4 +1,5 @@
 import { cssColorToRgba } from "./color";
+import { ImportMode } from "../types.d";
 import type { ImportSummary } from "../types.d";
 
 const validTypes = new Set(["COLOR", "FLOAT", "BOOLEAN", "STRING"]);
@@ -237,16 +238,20 @@ function parseLiteralValue(
  * convention back into real Figma variable aliases.
  *
  * @param rawFiles - Raw JSON text of each selected file
- * @param replaceExisting - If true, every existing local variable collection
- *   is deleted before importing (a clean re-sync instead of an additive merge)
+ * @param importMode - How to reconcile the import against existing local
+ *   collections: additive merge, update-existing-only, merge-then-prune
+ *   (sync), or wipe-then-import (clean). See {@link ImportMode}.
  */
-export async function importVariables(rawFiles: string[], replaceExisting: boolean): Promise<ImportSummary> {
+export async function importVariables(rawFiles: string[], importMode: ImportMode): Promise<ImportSummary> {
   const summary: ImportSummary = {
     collectionsCreated: 0,
     collectionsReused: 0,
+    collectionsDeleted: 0,
     modesCreated: 0,
+    modesDeleted: 0,
     variablesCreated: 0,
     variablesUpdated: 0,
+    variablesDeleted: 0,
     valuesSet: 0,
     aliasesResolved: 0,
     warnings: [],
@@ -260,10 +265,11 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
     return summary;
   }
 
-  if (replaceExisting) {
+  if (importMode === ImportMode.CLEAN) {
     const existing = await figma.variables.getLocalVariableCollectionsAsync();
     for (const collection of existing) {
       collection.remove();
+      summary.collectionsDeleted += 1;
     }
   }
 
@@ -286,7 +292,13 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
   for (const [collectionName, modeNames] of modeNamesByCollection) {
     let collection = collectionsByName.get(collectionName);
     let isNewCollection = false;
+
     if (!collection) {
+      // Update-only never creates: a collection missing locally means every
+      // record under it is skipped entirely (handled by the `!collection`
+      // guards in phases 2/3 below).
+      if (importMode === ImportMode.UPDATE_ONLY) continue;
+
       collection = figma.variables.createVariableCollection(collectionName);
       if (hasPrivateNamingConvention(collectionName)) {
         collection.hiddenFromPublishing = true;
@@ -301,6 +313,7 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
     modeNames.forEach((modeName, index) => {
       const existingMode = collection!.modes.find((m) => m.name === modeName);
       if (existingMode) return;
+      if (importMode === ImportMode.UPDATE_ONLY) return;
 
       if (isNewCollection && index === 0) {
         // Rename the collection's auto-created default mode instead of adding a new one.
@@ -346,6 +359,9 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
       variable = existingVariable;
       summary.variablesUpdated += 1;
     } else {
+      // Update-only never creates a variable that doesn't already exist.
+      if (importMode === ImportMode.UPDATE_ONLY) continue;
+
       variable = figma.variables.createVariable(varName, collection, record.resolvedType);
       if (hasPrivateNamingConvention(varName)) {
         variable.hiddenFromPublishing = true;
@@ -433,6 +449,51 @@ export async function importVariables(rawFiles: string[], replaceExisting: boole
       summary.warnings.push(
         `Failed to set alias for "${record.pathParts.join("/")}" in "${record.collectionName}" (${record.modeName}): ${err instanceof Error ? err.message : String(err)}`
       );
+    }
+  }
+
+  // --- Phase 4: prune (SYNC only) — after merging, delete anything anywhere
+  // in the document that isn't present in the imported file: whole
+  // collections the file never mentions, and leftover variables/modes inside
+  // collections it does mention.
+  if (importMode === ImportMode.SYNC) {
+    for (const collection of collectionsByName.values()) {
+      const modeNames = modeNamesByCollection.get(collection.name);
+
+      if (!modeNames) {
+        // Not present in the file at all — delete the whole collection.
+        collection.remove();
+        summary.collectionsDeleted += 1;
+        continue;
+      }
+
+      const keptVariableNames = new Set(
+        records
+          .filter((record) => record.collectionName === collection.name)
+          .map((record) => record.pathParts.join("/"))
+      );
+
+      const existingVariables = await Promise.all(
+        collection.variableIds.map((id) => figma.variables.getVariableByIdAsync(id))
+      );
+      for (const variable of existingVariables) {
+        if (variable && !keptVariableNames.has(variable.name)) {
+          variable.remove();
+          summary.variablesDeleted += 1;
+        }
+      }
+
+      for (const mode of collection.modes) {
+        if (modeNames.includes(mode.name)) continue;
+        try {
+          collection.removeMode(mode.modeId);
+          summary.modesDeleted += 1;
+        } catch (err) {
+          summary.warnings.push(
+            `Could not remove mode "${mode.name}" from collection "${collection.name}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
     }
   }
 

--- a/src/views/ImportJSON.tsx
+++ b/src/views/ImportJSON.tsx
@@ -14,16 +14,17 @@ interface ImportJSONProps {
 
 /**
  * JSON import view: pick a previously-exported VarVar JSON file (or files),
- * optionally replace all existing variables, and recreate collections,
- * modes, variables and linked-variable references in the document.
+ * choose how to reconcile against existing variables (merge, merge + prune,
+ * or clean), and recreate collections, modes, variables and linked-variable
+ * references in the document.
  */
 export const ImportJSON: React.FC<ImportJSONProps> = ({ editorType = "" }) => {
     const {
         fileNames,
         fileContents,
         setFiles,
-        replaceExisting,
-        setReplaceExisting,
+        importMode,
+        setImportMode,
         confirmDialogOpen,
         setConfirmDialogOpen,
         isImporting,
@@ -47,8 +48,8 @@ export const ImportJSON: React.FC<ImportJSONProps> = ({ editorType = "" }) => {
             <FileImportInput fileNames={fileNames} onFilesSelected={setFiles} />
 
             <ImportOptions
-                replaceExisting={replaceExisting}
-                onReplaceExistingChange={setReplaceExisting}
+                importMode={importMode}
+                onImportModeChange={setImportMode}
             />
 
             <Button
@@ -90,6 +91,7 @@ export const ImportJSON: React.FC<ImportJSONProps> = ({ editorType = "" }) => {
 
             <ConfirmReplaceDialog
                 open={confirmDialogOpen}
+                mode={importMode}
                 onOpenChange={setConfirmDialogOpen}
                 onConfirm={handleConfirmReplace}
             />


### PR DESCRIPTION
## Summary
- Replaces the single "replace existing variables" boolean toggle on the JSON import view with four explicit modes (`ImportMode` enum):
  - **Merge** — create missing collections/modes/variables, update matches by name. Nothing is ever deleted.
  - **Update only** — touch only what already exists in *both* the file and the document; nothing created, nothing deleted.
  - **Merge and delete anything not in the file (Sync)** — merge first, then delete anything anywhere in the document that isn't in the file, including whole collections the file never mentions. Matches are updated in place (not deleted+recreated), so their component bindings survive.
  - **Clean import** — today's existing behaviour: wipe every local collection, then import fresh. Every variable is recreated, so every existing component binding breaks, even where the recreated variable matches exactly.
- Confirmation dialog now only gates Sync and Clean (the two modes that can delete something); its copy is tailored per mode.
- `ImportSummary` gained `variablesDeleted` / `modesDeleted` / `collectionsDeleted`, surfaced in the import summary panel.

## Test plan
- [x] `npm run tsc`
- [x] `npm run build`
- [x] Manual check in Figma: run each of the 4 modes against a document with existing variables/components bound to them, confirm bindings survive for Merge/Update only/Sync-matches and break only where expected